### PR TITLE
Bump phonenumbers version to v8.13.5

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,10 +4,10 @@ jobs:
         docker:
             - image: python:3.7-alpine
         steps:
-            - checkout
             - run:
                 name: Install packages
                 command: apk add gcc musl-dev git openssh-client
+            - checkout
             - run:
                 name: Install Python packages
                 command: pip install -r requirements.txt
@@ -19,10 +19,10 @@ jobs:
         docker:
             - image: python:3.8-alpine
         steps:
-            - checkout
             - run:
                 name: Install packages
                 command: apk add gcc musl-dev git openssh-client
+            - checkout
             - run:
                 name: Install Python packages
                 command: pip install -r requirements.txt
@@ -34,10 +34,10 @@ jobs:
         docker:
             - image: python:3.9-alpine
         steps:
-            - checkout
             - run:
                 name: Install packages
                 command: apk add gcc musl-dev git openssh-client
+            - checkout
             - run:
                 name: Install Python packages
                 command: pip install -r requirements.txt
@@ -49,10 +49,10 @@ jobs:
         docker:
             - image: python:3.8-alpine
         steps:
-            - checkout
             - run:
                 name: Install packages
                 command: apk add gcc musl-dev git openssh-client
+            - checkout
             - run:
                 name: Install Python packages
                 command: pip install -r requirements.txt

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ pytest==4.5.0
 pytest-cov==2.7.1
 tox==3.11.1
 docformatter==1.3
-black==19.3b0
+black==22.3.0
 flake8==3.7.7
 pycodestyle==2.5.0
 autoflake==1.3

--- a/setup.py
+++ b/setup.py
@@ -36,7 +36,7 @@ with open(
 
 setup(
     name="py-phone-number-fmt",
-    version="1.2b2",
+    version="1.2b3",
     packages=find_packages(),
     include_package_data=True,
     license="MIT License",
@@ -47,7 +47,7 @@ setup(
     author="Sector Labs",
     author_email="open-source@sectorlabs.ro",
     keywords=["phone number", "phone", "formatting", "validation"],
-    install_requires=["phonenumbers==8.12.21"],
+    install_requires=["phonenumbers==8.13.5"],
     classifiers=[
         "Intended Audience :: Developers",
         "License :: OSI Approved :: MIT License",


### PR DESCRIPTION
Besides bumping the phonenumbers version to v8.13.5, this PR also fixed some issues with the circleci integration.

- In the circleci config file, the `checkout` command should run after installing the necessary packages like `git` and `openssh-client`.
- The CircleCI deploy key was not present in GitHub (might be due to [this](https://docs.github.com/en/authentication/troubleshooting-ssh/deleted-or-missing-ssh-keys)). The fix was to delete the existing one from CircleCI and add a new one (CircleCI automatically adds the ssh key to GitHub as well).
- The `format_verify` command did throw an error which was fixed after bumping the black version to the same one we currently use on strat.

[#184359995]